### PR TITLE
ES-156: Remove variant DOM elements

### DIFF
--- a/src/blocks/content-optimization/view.js
+++ b/src/blocks/content-optimization/view.js
@@ -228,6 +228,7 @@ const gpOptimizeFrontend = () => {
 						winnerVariant = variant;
 					} else {
 						variant.style.display = 'none';
+						variant.remove();
 					}
 				}
 


### PR DESCRIPTION
Remove the DOM elements of variants not shown instead of only hiding them.

Closes #7 