### PR TITLE
Fix UTM tag presets in variants

### DIFF
--- a/src/components/VariantTargeting/Conditional.js
+++ b/src/components/VariantTargeting/Conditional.js
@@ -93,9 +93,6 @@ const Conditional = ( {
 			setTypeSelection( selected );
 			setType( selected );
 		}
-
-		// The key is used for multiple different types. It can be confusing if the value is saved when changing types.
-		setConditionalKey( '' );
 	};
 
 	/**


### PR DESCRIPTION
Removed overwriting the conditional key after setting it when UTM tag presets were chosen in the variant settings.

Fixes #20 